### PR TITLE
Consolidated the insert/update steps for simplicity.

### DIFF
--- a/src/de/j4velin/pedometer/BootReceiver.java
+++ b/src/de/j4velin/pedometer/BootReceiver.java
@@ -36,7 +36,7 @@ public class BootReceiver extends BroadcastReceiver {
 			Logger.log("booted");
 		Database db = new Database(context);
 		db.open();
-		db.insertDay(Util.getToday(), 0); // device just booted; wont do
+		db.insertSteps(Util.getToday(), 0); // device just booted; wont do
 											// anything if there is already a
 											// row for today
 		NewDayReceiver.sheduleAlarmForNextDay(context);

--- a/src/de/j4velin/pedometer/Database.java
+++ b/src/de/j4velin/pedometer/Database.java
@@ -55,28 +55,41 @@ public class Database extends SQLiteOpenHelper {
 	public void onUpgrade(final SQLiteDatabase db, int oldVersion, int newVersion) {
 	}
 
-	/**
-	 * Inserts a new entry in the database, if there is no entry for the given date yet.
-	 * Use updateSteps(long date, int steps) if an entry for this date already exists.
-	 * 
-	 * @param date the date in ms since 1970
-	 * @param steps the steps for this date
-	 */
-	public void insertDay(final long date, int steps) {
-		Cursor c = database.query(DB_NAME, new String[] { "date" }, "date = ?", new String[] { String.valueOf(date) }, null,
-				null, null);
-		if (c.getCount() == 0) {
-			ContentValues values = new ContentValues();
-			values.put("date", date);
-			values.put("steps", steps);
-			database.insert(DB_NAME, null, values);
-		}
-		c.close();
-		if (Logger.LOG) {
-			Logger.log("insertDay " + date + " / " + steps);
-			logState();
-		}
-	}
+    /**
+     -	 * Inserts a new entry in the database, if there is no entry for the given date yet, else it'll just update.
+     -	 *
+     -	 * @param date the date in ms since 1970
+     -	 * @param steps the steps for this date
+     -	 */
+    public void insertSteps(final long date, int steps)
+    {
+        Cursor c = database.query(DB_NAME, new String[] { "date" }, "date = ?", new String[] { String.valueOf(date) }, null, null, null);
+
+        ContentValues values = new ContentValues();
+        values.put("date", date);
+        values.put("steps", steps);
+
+        if (c.getCount() == 0)
+        {
+            database.insert(DB_NAME, null, values);
+
+            if (Logger.LOG) {
+                Logger.log("insertSteps: Inserted steps " + date + " / " + steps);
+                logState();
+            }
+        }
+        else
+        {
+            database.update(DB_NAME, values, "date = " + date, null);
+
+            if (Logger.LOG) {
+                Logger.log("insertSteps: Updated steps " + date + " / " + steps);
+                logState();
+            }
+        }
+
+        c.close();
+    }
 
 	/**
 	 * Writes the current steps database to the log
@@ -103,22 +116,6 @@ public class Database extends SQLiteOpenHelper {
 	Cursor query(final String[] columns, final String selection, final String[] selectionArgs, final String groupBy,
 			final String having, final String orderBy, final String limit) {
 		return database.query(DB_NAME, columns, selection, selectionArgs, groupBy, having, orderBy, limit);
-	}
-
-	/**
-	 * Adds 'steps' steps to the row for the date 'date'
-	 * 
-	 * @param date
-	 *            the date to update the steps for in millis since 1970
-	 * @param steps
-	 *            the steps to add to the current steps-value for the date
-	 */
-	public void updateSteps(final long date, int steps) {
-		database.execSQL("UPDATE " + DB_NAME + " SET steps = steps + " + steps + " WHERE date = " + date);
-		if (Logger.LOG) {
-			Logger.log("updateSteps " + date + " / " + steps);
-			logState();
-		}
 	}
 
 	/**

--- a/src/de/j4velin/pedometer/OverviewFragment.java
+++ b/src/de/j4velin/pedometer/OverviewFragment.java
@@ -235,7 +235,7 @@ public class OverviewFragment extends Fragment implements SensorEventListener {
 			// initializing them with -STEPS_SINCE_BOOT
 			Database db = new Database(getActivity());
 			db.open();
-			db.insertDay(Util.getToday(), -(int) event.values[0]);
+			db.insertSteps(Util.getToday(), -(int) event.values[0]);
 			db.close();
 			todayOffset = -(int) event.values[0];
 		}

--- a/src/de/j4velin/pedometer/SettingsFragment.java
+++ b/src/de/j4velin/pedometer/SettingsFragment.java
@@ -264,7 +264,7 @@ public class SettingsFragment extends PreferenceFragment implements OnPreference
 					while ((line = in.readLine()) != null) {
 						data = line.split(";");
 						try {
-							db.insertDay(Long.valueOf(data[0]), Integer.valueOf(data[1]));
+							db.insertSteps(Long.valueOf(data[0]), Integer.valueOf(data[1]));
 						} catch (NumberFormatException nfe) {
 							skips++;
 						}

--- a/src/de/j4velin/pedometer/background/NewDayReceiver.java
+++ b/src/de/j4velin/pedometer/background/NewDayReceiver.java
@@ -44,13 +44,13 @@ public class NewDayReceiver extends BroadcastReceiver {
 		final Calendar yesterday = Calendar.getInstance();
 		yesterday.setTimeInMillis(Util.getToday()); // today
 		yesterday.add(Calendar.DAY_OF_YEAR, -1); // yesterday
-		db.updateSteps(yesterday.getTimeInMillis(), SensorListener.steps);
+		db.insertSteps(yesterday.getTimeInMillis(), SensorListener.steps);
 
 		// if - for whatever reason - there still is a
 		// negative value in
 		// yesterdays steps, set it to 0 instead
 		if (db.getSteps(yesterday.getTimeInMillis()) < 0) {
-			db.updateSteps(yesterday.getTimeInMillis(),
+			db.insertSteps(yesterday.getTimeInMillis(),
 					-db.getSteps(yesterday.getTimeInMillis()));
 		}
 
@@ -60,7 +60,7 @@ public class NewDayReceiver extends BroadcastReceiver {
 		// --> offset for the following day = -5.000
 		// --> step-value of 5.001 then means there was 1
 		// step taken today
-		db.insertDay(Util.getToday(), -SensorListener.steps);
+		db.insertSteps(Util.getToday(), -SensorListener.steps);
 		if (Logger.LOG) {
 			Logger.log("offset for new day: " + (-SensorListener.steps));
 			db.logState();

--- a/src/de/j4velin/pedometer/background/ShutdownRecevier.java
+++ b/src/de/j4velin/pedometer/background/ShutdownRecevier.java
@@ -35,7 +35,7 @@ public class ShutdownRecevier extends BroadcastReceiver {
 		// next boot and therefore has to be saved now
 		Database db = new Database(context);
 		db.open();
-		db.updateSteps(Util.getToday(), SensorListener.steps);
+		db.insertSteps(Util.getToday(), SensorListener.steps);
 		db.close();
 		if (Logger.LOG)
 			Logger.log("last step value before shutdown: " + SensorListener.steps);


### PR DESCRIPTION
Using this method it should no longer require NewDayReceiver as we’re
always storing the most up to date steps for the current day at the
time of update.

Unless of course there’s another use for NewDayReceiver I’m not seeing
(I’ve not had a good look over the code).

The ShutdownRecevier is also VERY unreliable, what if the phone
crashes? I’m going to look at a better way of storing steps in the db
as I’ve lost steps myself from the app/phone crashing a few times.
