### PR TITLE
When restoring from backup, overwrite existing days instead of skipping them

### DIFF
--- a/src/main/java/de/j4velin/pedometer/ui/Fragment_Settings.java
+++ b/src/main/java/de/j4velin/pedometer/ui/Fragment_Settings.java
@@ -291,7 +291,7 @@ public class Fragment_Settings extends PreferenceFragment implements OnPreferenc
     /**
      * Imports previously exported data from a csv file
      * <p/>
-     * Requires external storage to be readable. Skips days for which there is already an entry in the database
+     * Requires external storage to be readable. Overwrites days for which there is already an entry in the database
      */
     private void importCsv() {
         if (Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED)) {

--- a/src/main/java/de/j4velin/pedometer/ui/Fragment_Settings.java
+++ b/src/main/java/de/j4velin/pedometer/ui/Fragment_Settings.java
@@ -310,7 +310,7 @@ public class Fragment_Settings extends PreferenceFragment implements OnPreferenc
             Database db = Database.getInstance(getActivity());
             String line;
             String[] data;
-            int ignored = 0, inserted = 0, skips = 0;
+            int ignored = 0, inserted = 0, overwritten = 0;
             BufferedReader in;
             try {
                 in = new BufferedReader(new FileReader(f));
@@ -321,7 +321,7 @@ public class Fragment_Settings extends PreferenceFragment implements OnPreferenc
                                 Integer.valueOf(data[1]))) {
                             inserted++;
                         } else {
-                            skips++;
+                            overwritten++;
                         }
                     } catch (Exception nfe) {
                         ignored++;
@@ -343,7 +343,7 @@ public class Fragment_Settings extends PreferenceFragment implements OnPreferenc
                 db.close();
             }
             String message = getString(R.string.entries_imported, inserted);
-            if (skips > 0) message += "\n\n" + getString(R.string.entries_skipped, skips);
+            if (overwritten > 0) message += "\n\n" + getString(R.string.entries_overwritten, overwritten);
             if (ignored > 0) message += "\n\n" + getString(R.string.entries_ignored, ignored);
             new AlertDialog.Builder(getActivity()).setMessage(message)
                     .setPositiveButton(android.R.string.ok, new OnClickListener() {

--- a/src/main/res/values-bn/strings.xml
+++ b/src/main/res/values-bn/strings.xml
@@ -36,7 +36,7 @@
     <string name="start">শুরু</string>
     <string name="text_color">লেখার রঙ:</string>
     <string name="step_size_summary">বর্তমান পদক্ষেপের দীর্ঘ: %1$.2f %2$s</string>
-    <string name="entries_skipped">%d এন্ট্রিগুলি ছেড়ে দেওয়া হয়েছে কারণ ইতিমধ্যে এই দিনগুলির জন্য তথ্য আছে</string>
+    <string name="entries_overwritten">%d এন্ট্রিগুলি ছেড়ে দেওয়া হয়েছে কারণ ইতিমধ্যে এই দিনগুলির জন্য তথ্য আছে</string>
     <string name="split_count">বিভক্ত গণনা</string>
     <string name="since">%s থেকে</string>
     <string name="signed_in">%s হিসাবে সাইন ইন</string>

--- a/src/main/res/values-bn/strings.xml
+++ b/src/main/res/values-bn/strings.xml
@@ -36,7 +36,6 @@
     <string name="start">শুরু</string>
     <string name="text_color">লেখার রঙ:</string>
     <string name="step_size_summary">বর্তমান পদক্ষেপের দীর্ঘ: %1$.2f %2$s</string>
-    <string name="entries_overwritten">%d এন্ট্রিগুলি ছেড়ে দেওয়া হয়েছে কারণ ইতিমধ্যে এই দিনগুলির জন্য তথ্য আছে</string>
     <string name="split_count">বিভক্ত গণনা</string>
     <string name="since">%s থেকে</string>
     <string name="signed_in">%s হিসাবে সাইন ইন</string>

--- a/src/main/res/values-de/strings.xml
+++ b/src/main/res/values-de/strings.xml
@@ -24,7 +24,7 @@
     <string name="data_saved">Daten gespeichert in %s</string>
     <string name="entries_imported">%d Einträge wurden importiert</string>
     <string name="entries_ignored">%d Einträge wurden ignoriert, da diese in keinem gültigen Format vorlagen</string>
-    <string name="entries_skipped">%d Einträge wurden übersprungen, da für diese Tage bereits Daten vorliegen</string>
+    <string name="entries_overwritten">%d Einträge wurden übersprungen, da für diese Tage bereits Daten vorliegen</string>
     <string name="sign_in_necessary">Login erforderlich</string>
     <string name="please_sign_in_with_your_google_account">Bitte logge dich mit deinem Google+ Konto ein um diese Funktion zu nutzen.</string>
     <string name="steps">Schritte</string>

--- a/src/main/res/values-de/strings.xml
+++ b/src/main/res/values-de/strings.xml
@@ -24,7 +24,6 @@
     <string name="data_saved">Daten gespeichert in %s</string>
     <string name="entries_imported">%d Einträge wurden importiert</string>
     <string name="entries_ignored">%d Einträge wurden ignoriert, da diese in keinem gültigen Format vorlagen</string>
-    <string name="entries_overwritten">%d Einträge wurden übersprungen, da für diese Tage bereits Daten vorliegen</string>
     <string name="sign_in_necessary">Login erforderlich</string>
     <string name="please_sign_in_with_your_google_account">Bitte logge dich mit deinem Google+ Konto ein um diese Funktion zu nutzen.</string>
     <string name="steps">Schritte</string>

--- a/src/main/res/values-es/strings.xml
+++ b/src/main/res/values-es/strings.xml
@@ -24,6 +24,7 @@
     <string name="data_saved">Datos guardados en %s</string>
     <string name="entries_imported">%d entradas recuperadas</string>
     <string name="entries_ignored">%d entradas fueron ignoradas ya que no contenían datos válidos</string>
+    <string name="entries_overwritten">%d entradas fueron sobreescritas con los datos importados</string>
     <string name="sign_in_necessary">Inicio de sesión necesario</string>
     <string name="please_sign_in_with_your_google_account">Por favor, inicia sesión con tu cuenta de Google+ para usar esta funcionalidad.</string>
     <string name="steps">pasos</string>

--- a/src/main/res/values-fr/strings.xml
+++ b/src/main/res/values-fr/strings.xml
@@ -26,7 +26,6 @@
     <string name="data_saved">Données sauvegardées dans %s</string>
     <string name="entries_imported">%d entrées importées</string>
     <string name="entries_ignored">%d entrées sont ignorées pour cause de données invalides</string>
-    <string name="entries_overwritten">%d entrées sont ignorées car déjà existant pour ce jour</string>
     <string name="sign_in_necessary">Enregistrement nécessaire</string>
     <string name="please_sign_in_with_your_google_account">Merci de vous enregistrer avec votre compte Google+ pour utiliser cette fonctionnalité.</string>
     <string name="steps">pas</string>

--- a/src/main/res/values-fr/strings.xml
+++ b/src/main/res/values-fr/strings.xml
@@ -26,7 +26,7 @@
     <string name="data_saved">Données sauvegardées dans %s</string>
     <string name="entries_imported">%d entrées importées</string>
     <string name="entries_ignored">%d entrées sont ignorées pour cause de données invalides</string>
-    <string name="entries_skipped">%d entrées sont ignorées car déjà existant pour ce jour</string>
+    <string name="entries_overwritten">%d entrées sont ignorées car déjà existant pour ce jour</string>
     <string name="sign_in_necessary">Enregistrement nécessaire</string>
     <string name="please_sign_in_with_your_google_account">Merci de vous enregistrer avec votre compte Google+ pour utiliser cette fonctionnalité.</string>
     <string name="steps">pas</string>

--- a/src/main/res/values-it/strings.xml
+++ b/src/main/res/values-it/strings.xml
@@ -56,6 +56,5 @@
     <string name="your_progress_will_be_shown_here_soon">I tuoi progressi saranno presto visibili qui</string>
     <string name="entries_ignored">%d voci sono state saltate poiché non contenevano dati validi</string>
     <string name="entries_imported">Sono state importate %d voci</string>
-    <string name="entries_overwritten">Sono state saltate %d voci poiché esistevano già dei dati per quei giorni</string>
 
 </resources>

--- a/src/main/res/values-it/strings.xml
+++ b/src/main/res/values-it/strings.xml
@@ -56,6 +56,6 @@
     <string name="your_progress_will_be_shown_here_soon">I tuoi progressi saranno presto visibili qui</string>
     <string name="entries_ignored">%d voci sono state saltate poiché non contenevano dati validi</string>
     <string name="entries_imported">Sono state importate %d voci</string>
-    <string name="entries_skipped">Sono state saltate %d voci poiché esistevano già dei dati per quei giorni</string>
+    <string name="entries_overwritten">Sono state saltate %d voci poiché esistevano già dei dati per quei giorni</string>
 
 </resources>

--- a/src/main/res/values-ja/strings.xml
+++ b/src/main/res/values-ja/strings.xml
@@ -23,7 +23,7 @@
     <string name="data_saved">%s にデータを保存しました</string>
     <string name="entries_imported">%d 件のデータを復元しました</string>
     <string name="entries_ignored">%d 件の無効なデータをスキップしました</string>
-    <string name="entries_skipped">%d 件の既に存在する日付のデータをスキップしました</string>
+    <string name="entries_overwritten">%d 件の既に存在する日付のデータをスキップしました</string>
     <string name="sign_in_necessary">サインインが必要です</string>
     <string name="please_sign_in_with_your_google_account">この機能を利用するにはGoogle+のアカウントでサインインしてください</string>
     <string name="steps">歩</string>

--- a/src/main/res/values-ja/strings.xml
+++ b/src/main/res/values-ja/strings.xml
@@ -23,7 +23,6 @@
     <string name="data_saved">%s にデータを保存しました</string>
     <string name="entries_imported">%d 件のデータを復元しました</string>
     <string name="entries_ignored">%d 件の無効なデータをスキップしました</string>
-    <string name="entries_overwritten">%d 件の既に存在する日付のデータをスキップしました</string>
     <string name="sign_in_necessary">サインインが必要です</string>
     <string name="please_sign_in_with_your_google_account">この機能を利用するにはGoogle+のアカウントでサインインしてください</string>
     <string name="steps">歩</string>

--- a/src/main/res/values-ko/strings.xml
+++ b/src/main/res/values-ko/strings.xml
@@ -24,7 +24,7 @@
     <string name="data_saved">자료 저장됨: %s</string>
     <string name="entries_imported">%d 개 항목 불러옴</string>
     <string name="entries_ignored">%d 개 항목은 올바른 자료를 포함하지 않으므로 무시되었습니다</string>
-    <string name="entries_skipped">%d 개 항목은 이미 해당 기간동안의 자료가 존재하므로 건너뛰었습니다</string>
+    <string name="entries_overwritten">%d 개 항목은 이미 해당 기간동안의 자료가 존재하므로 건너뛰었습니다</string>
     <string name="sign_in_necessary">로그인 필요</string>
     <string name="please_sign_in_with_your_google_account">이 기능을 사용하려면 Google+ 계정에 로그인하세요</string>
     <string name="steps">걸음 수</string>

--- a/src/main/res/values-ko/strings.xml
+++ b/src/main/res/values-ko/strings.xml
@@ -24,7 +24,6 @@
     <string name="data_saved">자료 저장됨: %s</string>
     <string name="entries_imported">%d 개 항목 불러옴</string>
     <string name="entries_ignored">%d 개 항목은 올바른 자료를 포함하지 않으므로 무시되었습니다</string>
-    <string name="entries_overwritten">%d 개 항목은 이미 해당 기간동안의 자료가 존재하므로 건너뛰었습니다</string>
     <string name="sign_in_necessary">로그인 필요</string>
     <string name="please_sign_in_with_your_google_account">이 기능을 사용하려면 Google+ 계정에 로그인하세요</string>
     <string name="steps">걸음 수</string>

--- a/src/main/res/values-ru/strings.xml
+++ b/src/main/res/values-ru/strings.xml
@@ -24,7 +24,7 @@
     <string name="data_saved">Данные сохранены в %s</string>
     <string name="entries_imported">%d записей импортировано</string>
     <string name="entries_ignored">%d записей было проигнорировано, т.к. они не содержат корректных данных</string>
-    <string name="entries_skipped">%d записей было проигнорировано, т.к. за эти дни уже есть данные</string>    
+    <string name="entries_overwritten">%d записей было проигнорировано, т.к. за эти дни уже есть данные</string>
     <string name="sign_in_necessary">Необходимо выполнить вход</string>
     <string name="please_sign_in_with_your_google_account">Войдите с помощью учётной записи Google+ для использования данной функции.</string>
     <string name="steps">шагов</string>

--- a/src/main/res/values-ru/strings.xml
+++ b/src/main/res/values-ru/strings.xml
@@ -24,7 +24,6 @@
     <string name="data_saved">Данные сохранены в %s</string>
     <string name="entries_imported">%d записей импортировано</string>
     <string name="entries_ignored">%d записей было проигнорировано, т.к. они не содержат корректных данных</string>
-    <string name="entries_overwritten">%d записей было проигнорировано, т.к. за эти дни уже есть данные</string>
     <string name="sign_in_necessary">Необходимо выполнить вход</string>
     <string name="please_sign_in_with_your_google_account">Войдите с помощью учётной записи Google+ для использования данной функции.</string>
     <string name="steps">шагов</string>

--- a/src/main/res/values-sv/strings.xml
+++ b/src/main/res/values-sv/strings.xml
@@ -26,7 +26,6 @@
     <string name="data_saved">Data sparad i %s</string>
     <string name="entries_imported">%d poster importerade</string>
     <string name="entries_ignored">%d poster ignorerades eftersom de inte innehöll valid data</string>
-	<string name="entries_overwritten">%d poster hoppades över eftersom det redan existerar data för dessa dagar</string>
     <string name="sign_in_necessary">Inloggning nödvändig</string>
     <string name="please_sign_in_with_your_google_account">Logga in med ditt konto på Google+ för att använda den här funktionen.</string>
     <string name="steps">steg</string>

--- a/src/main/res/values-sv/strings.xml
+++ b/src/main/res/values-sv/strings.xml
@@ -26,7 +26,7 @@
     <string name="data_saved">Data sparad i %s</string>
     <string name="entries_imported">%d poster importerade</string>
     <string name="entries_ignored">%d poster ignorerades eftersom de inte innehöll valid data</string>
-	<string name="entries_skipped">%d poster hoppades över eftersom det redan existerar data för dessa dagar</string>
+	<string name="entries_overwritten">%d poster hoppades över eftersom det redan existerar data för dessa dagar</string>
     <string name="sign_in_necessary">Inloggning nödvändig</string>
     <string name="please_sign_in_with_your_google_account">Logga in med ditt konto på Google+ för att använda den här funktionen.</string>
     <string name="steps">steg</string>

--- a/src/main/res/values-tr/strings.xml
+++ b/src/main/res/values-tr/strings.xml
@@ -30,8 +30,6 @@
     <string name="data_saved">Veri %s konumuna kaydedildi.</string>
     <string name="entries_imported">%d girdi içeriye aktarıldı</string>
     <string name="entries_ignored">%d girdi, geçerli veri içermediğinden görmezden gelindi</string>
-    <string name="entries_overwritten">%d girdi, bu günler için zaten veri bulunduğundan atlandı
-    </string>
     <string name="sign_in_necessary">Hesaba giriş gerekli</string>
     <string name="please_sign_in_with_your_google_account">Bu özelliği kullanmak için lütfen Google+
         hesabınıza giriş yapın.

--- a/src/main/res/values-tr/strings.xml
+++ b/src/main/res/values-tr/strings.xml
@@ -30,7 +30,7 @@
     <string name="data_saved">Veri %s konumuna kaydedildi.</string>
     <string name="entries_imported">%d girdi içeriye aktarıldı</string>
     <string name="entries_ignored">%d girdi, geçerli veri içermediğinden görmezden gelindi</string>
-    <string name="entries_skipped">%d girdi, bu günler için zaten veri bulunduğundan atlandı
+    <string name="entries_overwritten">%d girdi, bu günler için zaten veri bulunduğundan atlandı
     </string>
     <string name="sign_in_necessary">Hesaba giriş gerekli</string>
     <string name="please_sign_in_with_your_google_account">Bu özelliği kullanmak için lütfen Google+

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -26,7 +26,7 @@
     <string name="data_saved">Data saved in %s</string>
     <string name="entries_imported">%d entries imported</string>
     <string name="entries_ignored">%d entries were ignored as they did not contain valid data</string>
-    <string name="entries_skipped">%d entries were skipped as there already exists data for these days</string>
+    <string name="entries_overwritten">%d entries were overwritten with imported data</string>
     <string name="sign_in_necessary">Sign in necessary</string>
     <string name="please_sign_in_with_your_google_account">Please sign in with your Google+ account to use this feature.</string>
     <string name="steps">steps</string>


### PR DESCRIPTION
Hello!

First, I love this app and I have been using it for more than a year. I like its approach of only using hardware step sensor so that it consumes no battery while still measuring steps.

I had almost no problems with it, until recently that when my device unexpectedly shutdowns, after starting up it shows an abnormal number of steps for the current day (hundreds of thousands and even millions!). It might be an old version bug, as I was running version 1.5 (I installed it through f-droid and I forgot to update it) and I have seen in the code that the unexpected shutdown recovery logic has recently been changed (it no longer displays a notification).

So, in order to remove those false step measurements, I thought to make a backup, modify the wrong step counts and then re-import it. While doing so, I realized that if the database already had data for a day in the backup file, the day was skipped from restore, favoring local database over backup.

So, I propose this change to make backup files take precedence over local data, so that we can modify the stored steps for a day without having to uninstall and the reinstall the app, loosing widgets, shortcuts and settings.

With my proposed change, when restoring data from a backup file, if the given day is already on the database, it is updated with the steps from the backup file. If it does not exists, it is created as before. I have also updated the javadoc and the associated string. But I cannot update translations (only spanish one, which I did), so we can wait for translators to update them before merging, or if that is not possible, we can remove the string in the other languages to make the user receive the english version instead of a misleading string.

Keep that good work!