### PR TITLE
wip: start working on dark theme

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -21,7 +21,7 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@android:style/Theme.DeviceDefault.Light.DarkActionBar"
+        android:theme="@style/AppTheme"
         tools:replace="label">
 
         <activity

--- a/src/main/res/values/styles.xml
+++ b/src/main/res/values/styles.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="AppTheme" parent="Theme.AppCompat.DayNight.DarkActionBar">
+    </style>
+</resources>


### PR DESCRIPTION
I've been toying around #86 and would like to add support a dark theme based on the
system DayNight theme.

It's not extremely clear to me what should be done but this is the gist of it 

- move theming to values (I think we could do without but Android Studio complains)
- inherit from appcompat DayNight to support system dark mode

at the moment the `appTheme` is not even populated but there you can put the values for the style of views and then apply the style on the single elements.